### PR TITLE
feature/add_note_time

### DIFF
--- a/tui/model.go
+++ b/tui/model.go
@@ -83,8 +83,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	m.textArea, cmd = m.textArea.Update(msg)
 	cmds = append(cmds, cmd)
 
-    m.textInputTime, cmd = m.textInputTime.Update(msg)
-    cmds = append(cmds, cmd)
+	m.textInputTime, cmd = m.textInputTime.Update(msg)
+	cmds = append(cmds, cmd)
 
 	switch msg := msg.(type) {
 	case spinner.TickMsg:
@@ -141,6 +141,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case "enter":
 				m.currNote = m.notes[m.listIndex]
 				m.textArea.SetValue(m.currNote.Body)
+                m.textInputTime.SetValue(m.currNote.TotalTime)
 				m.textArea.Focus()
 				m.textArea.CursorEnd()
 
@@ -203,18 +204,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case timeView:
 			switch key {
 			case "q":
-                return m, tea.Quit
+				return m, tea.Quit
 			case "esc":
 				m.state = bodyView
-			}
-		case bodyView:
-			switch key {
-			case "tab":
-                m.textInputTime.Focus()
-				m.state = timeView
+
 			case "ctrl+s":
 				body := m.textArea.Value()
 				m.currNote.Body = body
+				totalTime := m.textInputTime.Value()
+				m.currNote.TotalTime = totalTime
 
 				// Start loading spinner
 				m.isLoading = true
@@ -238,6 +236,48 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						return saveCompleteMsg{notes: newNotes}
 					},
 				)
+			}
+		case bodyView:
+			switch key {
+			case "tab":
+                if m.isEditing {
+                    m.textInputTime.Focus()
+                    m.textInputTime.CursorEnd()
+                } else {
+                    m.textInputTime.SetValue("")
+                    m.textInputTime.Focus()
+                    m.textInputTime.CursorEnd()
+                }
+				m.state = timeView
+				/*
+					case "ctrl+s":
+						body := m.textArea.Value()
+						m.currNote.Body = body
+
+						// Start loading spinner
+						m.isLoading = true
+
+						return m, tea.Batch(
+							m.spinner.Tick,
+							func() tea.Msg {
+								err := m.store.SaveNote(m.currNote)
+								if err != nil {
+									// Handle save error (simplified for example)
+									return tea.Quit
+								}
+								newNotes, err := m.store.GetNotes()
+								if err != nil {
+									// Handle fetch error (simplified for example)
+									return tea.Quit
+								}
+
+								// Simulate load operation with a delay
+								time.Sleep(400 * time.Millisecond) // Simulated delay
+								return saveCompleteMsg{notes: newNotes}
+							},
+						)
+
+				*/
 			case "esc":
 				m.isEditing = false // Reset editing case
 				m.state = listView

--- a/tui/model.go
+++ b/tui/model.go
@@ -83,6 +83,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	m.textArea, cmd = m.textArea.Update(msg)
 	cmds = append(cmds, cmd)
 
+    m.textInputTime, cmd = m.textInputTime.Update(msg)
+    cmds = append(cmds, cmd)
+
 	switch msg := msg.(type) {
 	case spinner.TickMsg:
 		if m.isLoading {
@@ -207,6 +210,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case bodyView:
 			switch key {
 			case "tab":
+                m.textInputTime.Focus()
 				m.state = timeView
 			case "ctrl+s":
 				body := m.textArea.Value()

--- a/tui/store.go
+++ b/tui/store.go
@@ -11,6 +11,7 @@ type Note struct {
 	Id        string
 	Title     string
 	Body      string
+    TotalTime string
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
@@ -30,6 +31,7 @@ func (s *Store) Init() error {
         Id TEXT not null primary key,
         Title text not null,
         Body text not null,
+        TotalTime TEXT,
         CreatedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         UpdatedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     );`
@@ -42,7 +44,7 @@ func (s *Store) Init() error {
 }
 
 func (s *Store) GetNotes() ([]Note, error) {
-	rows, err := s.conn.Query("SELECT Id, Title, Body, CreatedAt, UpdatedAt FROM Notes")
+	rows, err := s.conn.Query("SELECT Id, Title, Body, TotalTime, CreatedAt, UpdatedAt FROM Notes")
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +53,7 @@ func (s *Store) GetNotes() ([]Note, error) {
 	notes := []Note{}
 	for rows.Next() {
 		var note Note
-		rows.Scan(&note.Id, &note.Title, &note.Body, &note.CreatedAt, &note.UpdatedAt)
+		rows.Scan(&note.Id, &note.Title, &note.Body, &note.TotalTime, &note.CreatedAt, &note.UpdatedAt)
 		notes = append(notes, note)
 	}
 
@@ -69,16 +71,17 @@ func (s *Store) SaveNote(note Note) error {
 		note.UpdatedAt = now
 	}
 
-	upsertQuery := `INSERT INTO Notes (Id, Title, Body, CreatedAt, UpdatedAt)
-    VALUES (?, ?, ?, ?, ?)
+	upsertQuery := `INSERT INTO Notes (Id, Title, Body, TotalTime, CreatedAt, UpdatedAt)
+    VALUES (?, ?, ?, ?, ?, ?)
     ON CONFLICT(Id) DO UPDATE
     SET
         Title=excluded.Title,
         body=excluded.Body,
+        TotalTime=excluded.TotalTime,
         UpdatedAt=excluded.UpdatedAt;
     `
 
-	if _, err := s.conn.Exec(upsertQuery, note.Id, note.Title, note.Body, note.CreatedAt, note.UpdatedAt); err != nil {
+	if _, err := s.conn.Exec(upsertQuery, note.Id, note.Title, note.Body, note.TotalTime, note.CreatedAt, note.UpdatedAt); err != nil {
 		return err
 	}
 

--- a/tui/view.go
+++ b/tui/view.go
@@ -32,7 +32,7 @@ func (m model) View() string {
 			fmt.Sprintf(
 				"What’s your time?\n\n%s\n\n%s",
 				m.textInputTime.View(),
-				faintStyle.Render("(esc to quit)"),
+				faintStyle.Render("enter - next(now save), esc - quit"),
 			) + "\n"
 
 	case titleView:
@@ -51,7 +51,7 @@ func (m model) View() string {
 				faintStyle.Render("Updated At: ") + faintStyle.Render(m.currNote.UpdatedAt.Format("2006-01-02 15:04:05")) + "\n"
 		}
 
-		return header + noteDetails + faintStyle.Render("ctrl+s - save, esc - discard")
+		return header + noteDetails + faintStyle.Render("tab - next, esc - discard")
 
 	case listView:
 		var notesList string

--- a/tui/view.go
+++ b/tui/view.go
@@ -1,75 +1,84 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
 )
 
 var (
-    appNameStyle = lipgloss.NewStyle().Background(lipgloss.Color("99")).Padding(0, 1)
+	appNameStyle = lipgloss.NewStyle().Background(lipgloss.Color("99")).Padding(0, 1)
 
-    faintStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("255")).Faint(true)
+	faintStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("255")).Faint(true)
 
-    enumeratorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("99")).MarginRight(1)
+	enumeratorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("99")).MarginRight(1)
 
-    editNoteStyle = lipgloss.NewStyle().Background(lipgloss.Color("98")).Padding(0, 1)
-    editTitleNoteStyle = lipgloss.NewStyle().Background(lipgloss.Color("95")).Padding(0, 1)
-
+	editNoteStyle      = lipgloss.NewStyle().Background(lipgloss.Color("98")).Padding(0, 1)
+	editTitleNoteStyle = lipgloss.NewStyle().Background(lipgloss.Color("95")).Padding(0, 1)
 )
+
 func (m model) View() string {
-    header := appNameStyle.Render("NOTES APP") + "\n\n"
+	header := appNameStyle.Render("NOTES APP") + "\n\n"
 
-    if m.isLoading {
-        return header +
-            m.spinner.View() + " Loading..." + "\n\n"
-    }
+	if m.isLoading {
+		return header +
+			m.spinner.View() + " Loading..." + "\n\n"
+	}
 
-    switch m.state {
-    case titleView:
-        return header +
-            "Note title:\n\n" +
-            m.textInput.View() + "\n\n" +
-            faintStyle.Render("enter - save, esc - discard")
+	switch m.state {
+	case timeView:
+		return header +
+			fmt.Sprintf(
+				"What’s your time?\n\n%s\n\n%s",
+				m.textInputTime.View(),
+				faintStyle.Render("(esc to quit)"),
+			) + "\n"
 
-    case bodyView:
-        noteDetails := editNoteStyle.Render("Note:") + "\n\n" +
-            editTitleNoteStyle.Render(m.currNote.Title) + "\n\n" +
-            m.textArea.View() + "\n\n"
+	case titleView:
+		return header +
+			"Note title:\n\n" +
+			m.textInput.View() + "\n\n" +
+			faintStyle.Render("enter - save, esc - discard")
 
-        if m.isEditing {
-            noteDetails += faintStyle.Render("Created At: ") + faintStyle.Render(m.currNote.CreatedAt.Format("2006-01-02 15:04:05")) + "\n" +
-                faintStyle.Render("Updated At: ") + faintStyle.Render(m.currNote.UpdatedAt.Format("2006-01-02 15:04:05")) + "\n"
-        }
+	case bodyView:
+		noteDetails := editNoteStyle.Render("Note:") + "\n\n" +
+			editTitleNoteStyle.Render(m.currNote.Title) + "\n\n" +
+			m.textArea.View() + "\n\n"
 
-        return header + noteDetails + faintStyle.Render("ctrl+s - save, esc - discard")
+		if m.isEditing {
+			noteDetails += faintStyle.Render("Created At: ") + faintStyle.Render(m.currNote.CreatedAt.Format("2006-01-02 15:04:05")) + "\n" +
+				faintStyle.Render("Updated At: ") + faintStyle.Render(m.currNote.UpdatedAt.Format("2006-01-02 15:04:05")) + "\n"
+		}
 
-    case listView:
-        var notesList string
-        for i, n := range m.notes {
-            prefix := " "
-            if i == m.listIndex {
-                prefix = ">"
-            }
+		return header + noteDetails + faintStyle.Render("ctrl+s - save, esc - discard")
 
-            shortBody := strings.ReplaceAll(n.Body, "\n", " ")
-            if len(shortBody) > 30 {
-                shortBody = shortBody[:30] + "..." // Add ellipsis for truncated body
-            }
+	case listView:
+		var notesList string
+		for i, n := range m.notes {
+			prefix := " "
+			if i == m.listIndex {
+				prefix = ">"
+			}
 
-            notesList += enumeratorStyle.Render(prefix) + n.Title + " | " + faintStyle.Render(shortBody) + "\n\n"
-        }
-        // Conditionally add the "d - delete" option if there is more than one note
-        deleteOption := ""
-        if len(m.notes) >= 1 {
-            deleteOption = faintStyle.Render("d - delete") + ", "
-        }
+			shortBody := strings.ReplaceAll(n.Body, "\n", " ")
+			if len(shortBody) > 30 {
+				shortBody = shortBody[:30] + "..." // Add ellipsis for truncated body
+			}
 
-        newNoteOption := faintStyle.Render("n - new note") + ", "
-        exitCliOption := faintStyle.Render("q - quit")
+			notesList += enumeratorStyle.Render(prefix) + n.Title + " | " + faintStyle.Render(shortBody) + "\n\n"
+		}
+		// Conditionally add the "d - delete" option if there is more than one note
+		deleteOption := ""
+		if len(m.notes) >= 1 {
+			deleteOption = faintStyle.Render("d - delete") + ", "
+		}
 
-        return header + notesList + newNoteOption + deleteOption + exitCliOption
-    }
+		newNoteOption := faintStyle.Render("n - new note") + ", "
+		exitCliOption := faintStyle.Render("q - quit")
 
-    return header // Fallback to header if no state matches
+		return header + notesList + newNoteOption + deleteOption + exitCliOption
+	}
+
+	return header // Fallback to header if no state matches
 }


### PR DESCRIPTION
This pull request introduces a new feature allowing users to input and save a "TotalTime" value for each note in the TUI application. The changes span across multiple files, including updates to the model, view, and store components.

### New Feature: TotalTime Input and Save

**Model Updates:**
* Added `timeView` constant and `textInputTime` field to the `model` struct in `tui/model.go`. [[1]](diffhunk://#diff-89c13c9933645c78dd28717d3b20c96c8f89ea759ea7ff80004e5320b866a0edR18) [[2]](diffhunk://#diff-89c13c9933645c78dd28717d3b20c96c8f89ea759ea7ff80004e5320b866a0edR29)
* Initialized `textInputTime` in the `NewModel` function.
* Updated `Update` method to handle `textInputTime` updates and save operations. [[1]](diffhunk://#diff-89c13c9933645c78dd28717d3b20c96c8f89ea759ea7ff80004e5320b866a0edR86-R88) [[2]](diffhunk://#diff-89c13c9933645c78dd28717d3b20c96c8f89ea759ea7ff80004e5320b866a0edR144) [[3]](diffhunk://#diff-89c13c9933645c78dd28717d3b20c96c8f89ea759ea7ff80004e5320b866a0edR204-R252) [[4]](diffhunk://#diff-89c13c9933645c78dd28717d3b20c96c8f89ea759ea7ff80004e5320b866a0edR279-R280) [[5]](diffhunk://#diff-89c13c9933645c78dd28717d3b20c96c8f89ea759ea7ff80004e5320b866a0edL233-L234)

**Store Updates:**
* Added `TotalTime` field to the `Note` struct and updated database schema and queries to handle the new field in `tui/store.go`. [[1]](diffhunk://#diff-302c0dbb226a0870361f186733f2447938f116b777ec743df7a6f6e811e898ddR14) [[2]](diffhunk://#diff-302c0dbb226a0870361f186733f2447938f116b777ec743df7a6f6e811e898ddR34) [[3]](diffhunk://#diff-302c0dbb226a0870361f186733f2447938f116b777ec743df7a6f6e811e898ddL45-R47) [[4]](diffhunk://#diff-302c0dbb226a0870361f186733f2447938f116b777ec743df7a6f6e811e898ddL54-R56) [[5]](diffhunk://#diff-302c0dbb226a0870361f186733f2447938f116b777ec743df7a6f6e811e898ddL72-R84)

**View Updates:**
* Modified the `View` method to include a new case for `timeView` and display the `textInputTime` input field in `tui/view.go`. [[1]](diffhunk://#diff-b18b495ac25a8fba967ef09e1fbacd1589674e53b5a5bed5e49c290cd6c7fd9bR4) [[2]](diffhunk://#diff-b18b495ac25a8fba967ef09e1fbacd1589674e53b5a5bed5e49c290cd6c7fd9bL18-R20) [[3]](diffhunk://#diff-b18b495ac25a8fba967ef09e1fbacd1589674e53b5a5bed5e49c290cd6c7fd9bR30-R37) [[4]](diffhunk://#diff-b18b495ac25a8fba967ef09e1fbacd1589674e53b5a5bed5e49c290cd6c7fd9bL45-R54)