### PR TITLE
feature/project-select

### DIFF
--- a/tui/model.go
+++ b/tui/model.go
@@ -19,8 +19,6 @@ const (
 	projectSelectView
 )
 
-var choices = []string{"Taro", "Coffee", "Lychee"}
-
 type model struct {
 	state         uint
 	store         *Store
@@ -37,6 +35,8 @@ type model struct {
 
 	projectCursor int
 	projectChoice string
+
+    projects []Project
 }
 
 // Custom message for loading notes
@@ -58,6 +58,12 @@ func NewModel(store *Store) model {
 		log.Fatalf("unable to get notes: %v", err)
 	}
 
+    projects, err := store.GetProjects()
+    if err != nil {
+		log.Fatalf("unable to get projects: %v", err)
+    }
+
+
 	spin := spinner.New()
 	spin.Spinner = spinner.Dot
 
@@ -70,6 +76,7 @@ func NewModel(store *Store) model {
 		spinner:       spin,
 		isLoading:     false,
 		textInputTime: textinput.New(),
+        projects: projects,
 	}
 }
 
@@ -219,13 +226,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.state = timeView
 			case "down", "j":
                 m.projectCursor++
-                if m.projectCursor >= len(choices) {
+                if m.projectCursor >= len(m.projects) {
                     m.projectCursor = 0
                 }
 			case "up", "k":
                 m.projectCursor--
                 if m.projectCursor < 0 {
-                    m.projectCursor = len(choices) - 1
+                    m.projectCursor = len(m.projects) - 1
                 }
 			}
 		case timeView:

--- a/tui/model.go
+++ b/tui/model.go
@@ -16,8 +16,10 @@ const (
 	titleView
 	bodyView
 	timeView
-    projectSelectView
+	projectSelectView
 )
+
+var choices = []string{"Taro", "Coffee", "Lychee"}
 
 type model struct {
 	state         uint
@@ -32,6 +34,9 @@ type model struct {
 
 	spinner   spinner.Model
 	isLoading bool
+
+	projectCursor int
+	projectChoice string
 }
 
 // Custom message for loading notes
@@ -142,7 +147,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case "enter":
 				m.currNote = m.notes[m.listIndex]
 				m.textArea.SetValue(m.currNote.Body)
-                m.textInputTime.SetValue(m.currNote.TotalTime)
+				m.textInputTime.SetValue(m.currNote.TotalTime)
 				m.textArea.Focus()
 				m.textArea.CursorEnd()
 
@@ -203,13 +208,24 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.state = listView
 			}
 
-        case projectSelectView:
-            switch key {
-                case "q":
-                    return m, tea.Quit
-                case "esc":
-                    m.state = timeView
-            }
+		case projectSelectView:
+			switch key {
+			case "q":
+				return m, tea.Quit
+			case "esc":
+				m.state = timeView
+			case "down", "j":
+                m.projectCursor++
+                if m.projectCursor >= len(choices) {
+                    m.projectCursor = 0
+                }
+
+			case "up", "k":
+                m.projectCursor--
+                if m.projectCursor < 0 {
+                    m.projectCursor = len(choices) - 1
+                }
+			}
 		case timeView:
 			switch key {
 			case "q":
@@ -217,8 +233,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case "esc":
 				m.state = bodyView
 
-            case "enter":
-                m.state = projectSelectView
+			case "enter":
+				m.state = projectSelectView
 
 			case "ctrl+s":
 				body := m.textArea.Value()
@@ -252,14 +268,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case bodyView:
 			switch key {
 			case "tab":
-                if m.isEditing {
-                    m.textInputTime.Focus()
-                    m.textInputTime.CursorEnd()
-                } else {
-                    m.textInputTime.SetValue("")
-                    m.textInputTime.Focus()
-                    m.textInputTime.CursorEnd()
-                }
+				if m.isEditing {
+					m.textInputTime.Focus()
+					m.textInputTime.CursorEnd()
+				} else {
+					m.textInputTime.SetValue("")
+					m.textInputTime.Focus()
+					m.textInputTime.CursorEnd()
+				}
 				m.state = timeView
 				/*
 					case "ctrl+s":

--- a/tui/model.go
+++ b/tui/model.go
@@ -16,6 +16,7 @@ const (
 	titleView
 	bodyView
 	timeView
+    projectSelectView
 )
 
 type model struct {
@@ -201,12 +202,23 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case "esc":
 				m.state = listView
 			}
+
+        case projectSelectView:
+            switch key {
+                case "q":
+                    return m, tea.Quit
+                case "esc":
+                    m.state = timeView
+            }
 		case timeView:
 			switch key {
 			case "q":
 				return m, tea.Quit
 			case "esc":
 				m.state = bodyView
+
+            case "enter":
+                m.state = projectSelectView
 
 			case "ctrl+s":
 				body := m.textArea.Value()

--- a/tui/model.go
+++ b/tui/model.go
@@ -213,13 +213,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case "q":
 				return m, tea.Quit
 			case "esc":
+                m.textInputTime.Focus()
+                m.textInputTime.CursorEnd()
+
 				m.state = timeView
 			case "down", "j":
                 m.projectCursor++
                 if m.projectCursor >= len(choices) {
                     m.projectCursor = 0
                 }
-
 			case "up", "k":
                 m.projectCursor--
                 if m.projectCursor < 0 {
@@ -231,9 +233,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case "q":
 				return m, tea.Quit
 			case "esc":
+                // Make text area focus again
+                m.textInputTime.Blur() // Blur time input before switching back
+                m.textArea.Focus()
+                m.textArea.CursorEnd()
 				m.state = bodyView
 
 			case "enter":
+                // Blur textInputTime when transitioning out of timeView
+                m.textInputTime.Blur()
 				m.state = projectSelectView
 
 			case "ctrl+s":
@@ -276,6 +284,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.textInputTime.Focus()
 					m.textInputTime.CursorEnd()
 				}
+                // Blur textArea when transitioning out of bodyView
+                m.textArea.Blur()
 				m.state = timeView
 				/*
 					case "ctrl+s":
@@ -308,6 +318,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				*/
 			case "esc":
 				m.isEditing = false // Reset editing case
+                m.textArea.Blur() // Ensure focus is cleared
 				m.state = listView
 			}
 		}

--- a/tui/store.go
+++ b/tui/store.go
@@ -2,9 +2,10 @@ package tui
 
 import (
 	"database/sql"
+	"time"
+
 	"github.com/google/uuid"
 	_ "github.com/mattn/go-sqlite3" // unknown driver sqlite3 forgotten import
-	"time"
 )
 
 type Note struct {
@@ -12,6 +13,7 @@ type Note struct {
 	Title     string
 	Body      string
 	TotalTime string
+    Project Project
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
@@ -81,6 +83,7 @@ func (s *Store) Init() error {
 	return nil
 }
 
+/*
 func (s *Store) GetNotes() ([]Note, error) {
 	rows, err := s.conn.Query("SELECT Id, Title, Body, TotalTime, CreatedAt, UpdatedAt FROM Notes")
 	if err != nil {
@@ -95,6 +98,38 @@ func (s *Store) GetNotes() ([]Note, error) {
 		notes = append(notes, note)
 	}
 
+	return notes, nil
+}
+*/
+
+func (s *Store) GetNotes() ([]Note, error) {
+	query := `
+		SELECT
+			n.Id, n.Title, n.Body, n.TotalTime, n.CreatedAt, n.UpdatedAt,
+			p.Id AS ProjectId, p.Name AS ProjectName, p.Description AS ProjectDescription
+		FROM Notes n
+		INNER JOIN Projects p ON n.ProjectId = p.Id;
+	`
+
+	rows, err := s.conn.Query(query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var notes []Note
+	for rows.Next() {
+		var note Note
+		var project Project
+		if err := rows.Scan(
+			&note.Id, &note.Title, &note.Body, &note.TotalTime, &note.CreatedAt, &note.UpdatedAt,
+			&project.Id, &project.Name, &project.Description,
+		); err != nil {
+			return nil, err
+		}
+		note.Project = project // Attach the project details to the note
+		notes = append(notes, note)
+	}
 	return notes, nil
 }
 
@@ -162,4 +197,65 @@ func (s *Store) GetProjects() ([]Project, error) {
 	}
 
 	return projects, nil
+}
+
+func (s *Store) SaveNoteWithProject(note Note, projectId int) error {
+	now := time.Now().UTC()
+
+	if note.Id == "" {
+		note.Id = uuid.New().String()
+		note.CreatedAt = now
+		note.UpdatedAt = now
+	} else {
+		note.UpdatedAt = now
+	}
+
+	upsertQuery := `INSERT INTO Notes (Id, Title, Body, TotalTime, ProjectId, CreatedAt, UpdatedAt)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(Id) DO UPDATE
+    SET
+        Title=excluded.Title,
+        Body=excluded.Body,
+        TotalTime=excluded.TotalTime,
+        ProjectId=excluded.ProjectId,
+        UpdatedAt=excluded.UpdatedAt;`
+
+	if _, err := s.conn.Exec(upsertQuery, note.Id, note.Title, note.Body, note.TotalTime, projectId, note.CreatedAt, note.UpdatedAt); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+
+func (s *Store) GetNotesByProject(projectId int) ([]Note, error) {
+	rows, err := s.conn.Query(
+		"SELECT Id, Title, Body, TotalTime, CreatedAt, UpdatedAt FROM Notes WHERE ProjectId = ?", projectId)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	notes := []Note{}
+	for rows.Next() {
+		var note Note
+		rows.Scan(&note.Id, &note.Title, &note.Body, &note.TotalTime, &note.CreatedAt, &note.UpdatedAt)
+		notes = append(notes, note)
+	}
+
+	return notes, nil
+}
+
+func (s *Store) GetProjectById(projectId int) (Project, error) {
+	var project Project
+	query := "SELECT Id, Name, Description, CreatedAt, UpdatedAt FROM Projects WHERE Id = ?"
+	err := s.conn.QueryRow(query, projectId).Scan(
+		&project.Id, &project.Name, &project.Description, &project.CreatedAt, &project.UpdatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return Project{}, nil // Return zero value
+	} else if err != nil {
+		return Project{}, err
+	}
+	return project, nil
 }

--- a/tui/view.go
+++ b/tui/view.go
@@ -35,6 +35,23 @@ func (m model) View() string {
 				faintStyle.Render("enter - next(now save), esc - quit"),
 			) + "\n"
 
+	case projectSelectView:
+		s := strings.Builder{}
+		s.WriteString("What kind of Bubble Tea would you like to order?\n\n")
+
+		for i := 0; i < len(choices); i++ {
+			if m.projectCursor == i {
+				s.WriteString("(•) ")
+			} else {
+				s.WriteString("( ) ")
+			}
+
+            s.WriteString(choices[i])
+            s.WriteString("\n")
+		}
+
+		return header + s.String()
+
 	case titleView:
 		return header +
 			"Note title:\n\n" +

--- a/tui/view.go
+++ b/tui/view.go
@@ -39,14 +39,14 @@ func (m model) View() string {
 		s := strings.Builder{}
 		s.WriteString("What kind of Bubble Tea would you like to order?\n\n")
 
-		for i := 0; i < len(choices); i++ {
+		for i := 0; i < len(m.projects); i++ {
 			if m.projectCursor == i {
 				s.WriteString("(•) ")
 			} else {
 				s.WriteString("( ) ")
 			}
 
-            s.WriteString(choices[i])
+            s.WriteString(m.projects[i].Name)
             s.WriteString("\n")
 		}
 


### PR DESCRIPTION
This pull request introduces significant changes to the `tui` package, adding project management capabilities and updating the data model to support projects. The most important changes include the addition of project-related fields and methods, updates to the user interface to handle project selection, and modifications to the database schema and data access methods.

### Project Management Enhancements:

* Added `projectSelectView` to the `const` block and new fields `projectCursor`, `projects`, and `currProject` to the `model` struct in `tui/model.go`. [[1]](diffhunk://#diff-89c13c9933645c78dd28717d3b20c96c8f89ea759ea7ff80004e5320b866a0edR19) [[2]](diffhunk://#diff-89c13c9933645c78dd28717d3b20c96c8f89ea759ea7ff80004e5320b866a0edR35-R39)
* Updated the `NewModel` function to initialize projects from the store and set the initial project state. [[1]](diffhunk://#diff-89c13c9933645c78dd28717d3b20c96c8f89ea759ea7ff80004e5320b866a0edR61-R65) [[2]](diffhunk://#diff-89c13c9933645c78dd28717d3b20c96c8f89ea759ea7ff80004e5320b866a0edR78)

### User Interface Updates:

* Modified the `Update` method to handle project selection and project-related actions, such as saving a note with the selected project. [[1]](diffhunk://#diff-89c13c9933645c78dd28717d3b20c96c8f89ea759ea7ff80004e5320b866a0edR119-R127) [[2]](diffhunk://#diff-89c13c9933645c78dd28717d3b20c96c8f89ea759ea7ff80004e5320b866a0edR223-R312) [[3]](diffhunk://#diff-89c13c9933645c78dd28717d3b20c96c8f89ea759ea7ff80004e5320b866a0edR341) [[4]](diffhunk://#diff-89c13c9933645c78dd28717d3b20c96c8f89ea759ea7ff80004e5320b866a0edR354-R355) [[5]](diffhunk://#diff-89c13c9933645c78dd28717d3b20c96c8f89ea759ea7ff80004e5320b866a0edR388)
* Updated the `View` method to display the project selection interface.

### Database Schema and Data Access:

* Updated the `Store` struct and methods to handle projects, including creating the `Projects` table, saving projects, and fetching projects and notes by project. [[1]](diffhunk://#diff-302c0dbb226a0870361f186733f2447938f116b777ec743df7a6f6e811e898ddR5-R24) [[2]](diffhunk://#diff-302c0dbb226a0870361f186733f2447938f116b777ec743df7a6f6e811e898ddL30-R86) [[3]](diffhunk://#diff-302c0dbb226a0870361f186733f2447938f116b777ec743df7a6f6e811e898ddR103-R134) [[4]](diffhunk://#diff-302c0dbb226a0870361f186733f2447938f116b777ec743df7a6f6e811e898ddR168-R261)